### PR TITLE
Fix Dockerfile build with default feature set

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,23 +13,49 @@ FROM rust:1.95-slim-bookworm AS builder
 
 WORKDIR /usr/src/app
 
-# Minimal build deps — no OpenSSL (rustls is pure Rust).
+# Build deps. Beyond pkg-config + build-essential, the `extractors` feature
+# pulls in `rquest` → `boring-sys2` which statically compiles BoringSSL:
+#   * cmake / ninja / perl / python3 / golang-go — BoringSSL build system
+#   * git                                         — boring-sys2 invokes
+#                                                   `git init` + `git apply`
+#                                                   to apply bundled patches
+#   * clang + libclang-dev                        — bindgen needs libclang.so
+#     to generate BoringSSL FFI bindings
+#
+# The CI release workflow builds on native runners (see .github/workflows/
+# release.yml) that already ship all of the above, which is why this
+# Dockerfile has historically gotten away with a shorter list. A plain
+# `docker build .` without these panics inside the boring-sys2 build script.
 RUN apt-get update && apt-get install -y --no-install-recommends \
         pkg-config \
         build-essential \
+        cmake \
+        ninja-build \
+        perl \
+        python3 \
+        golang-go \
+        git \
+        clang \
+        libclang-dev \
         && rm -rf /var/lib/apt/lists/*
 
-# Dependency-only prebuild for layer caching
+# Dependency-only prebuild for layer caching. `crates/` is needed because
+# Cargo.toml has `[patch.crates-io] os_info = { path = "crates/os_info_stub" }`
+# — without it, cargo fails to resolve the workspace patch entry.
 COPY Cargo.toml Cargo.lock ./
+COPY crates ./crates
 RUN mkdir src && \
     echo "fn main() {}" > src/main.rs && \
     echo "pub fn add(l: usize, r: usize) -> usize { l + r }" > src/lib.rs && \
     cargo build --release && \
     rm -rf src target/release/deps/mediaflow*
 
-# Real build
-COPY src  ./src
-COPY tools ./tools
+# Real build. `static/` is embedded into the binary by rust-embed when the
+# `web-ui` feature is enabled (default), so it must be present at compile
+# time even though nothing references it at runtime.
+COPY src    ./src
+COPY tools  ./tools
+COPY static ./static
 RUN cargo build --release
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`docker build .` currently fails because the builder stage is missing several tooling dependencies and source directories that the default feature set requires. This PR makes a plain `docker build .` work end-to-end.

## What was wrong

### Missing apt packages

The `extractors` default feature pulls in `rquest` → `boring-sys2` (statically compiled BoringSSL) + `bindgen`. These need:

- **`cmake` / `ninja-build` / `perl` / `python3` / `golang-go`** — BoringSSL's build system.
- **`git`** — `boring-sys2`'s build script shells out to `git init` and `git apply` to apply its bundled BoringSSL patches before invoking cmake. Without git on PATH the build panics with `Err(NotFound)` at `boring-sys2-4.15.15/build/main.rs:482`.
- **`clang` + `libclang-dev`** — `bindgen` needs `libclang.so` to generate the BoringSSL FFI bindings; otherwise it panics with *"Unable to find libclang"* at `bindgen-0.72.1/lib.rs:616`.

### Missing source directories

- **`crates/`** — `Cargo.toml` has `[patch.crates-io] os_info = { path = "crates/os_info_stub" }`. The dependency-only prebuild stage copies only `Cargo.toml` and `Cargo.lock`, so cargo fails to resolve the patch entry.
- **`static/`** — embedded into the binary by `rust-embed` when the `web-ui` feature is enabled (default). The proc macro reads the directory at compile time, so it must be present during `cargo build`.

## Why this hasn't been noticed

The CI release workflow ([.github/workflows/release.yml](.github/workflows/release.yml)) builds native binaries on `ubuntu-24.04` / `ubuntu-24.04-arm` runners. Those images ship all of the apt packages pre-installed, and the whole repo is checked out via `actions/checkout` — so neither the tooling gap nor the COPY gap gets exercised there. `docker build` has no such safety net.

## Test plan

- [x] `docker build .` against a clean checkout → green
- [x] Resulting image starts and serves requests