### PR TITLE
Let api_password-in-body reach /generate_url(s) handlers

### DIFF
--- a/src/auth/middleware.rs
+++ b/src/auth/middleware.rs
@@ -14,6 +14,11 @@ use crate::error::AppError;
 
 const OPEN_ENDPOINTS: &[&str] = &[
     "/proxy/generate_url",
+    // URL-generation handlers authenticate via `api_password` in the JSON body,
+    // not query string — so the middleware must let these through untouched.
+    "/generate_url",
+    "/generate_urls",
+    "/generate_encrypted_or_encoded_url",
     "/health",
     // Web UI navigation paths (redirect to .html pages)
     "/speedtest",


### PR DESCRIPTION
## Summary

The auth middleware's `OPEN_ENDPOINTS` allowlist only lists the `/proxy/generate_url` variant, but there are three identical root-level routes that are Python-proxy compatibility mirrors:

- `POST /generate_url`
- `POST /generate_urls`
- `POST /generate_encrypted_or_encoded_url`

All three accept `api_password` in the **JSON request body** (see [`handler::generate_url`](https://github.com/mhdzumair/mediaflow-proxy-light/blob/main/src/proxy/handler.rs#L303) / `handler::generate_urls`), but the middleware only inspects query-string `token` / `api_password`. So every request to these three endpoints gets rejected with 401 before the handler runs, regardless of whether the body carries the correct password.

## What this breaks in the wild

Server-to-server callers written against the original Python mediaflow-proxy (aiostreams, mediafusion, comet, …) POST to `/generate_urls` to batch-encrypt proxy URLs. The documented contract is body-based auth, so they don't add query-string credentials. Against mediaflow-proxy-light with a non-empty `api_password`, every such call returns 401 and the caller drops the stream list entirely. A representative log line from aiostreams:

```
❌ | PROXY | Failed to generate proxy URLs: Error: 401: Unauthorized
⚠️ | PROXY | Failed to proxy 273 streams. Removing them from the list.
```

## The fix

Add the three root-level generators to `OPEN_ENDPOINTS` so the middleware defers to the handlers' own body-side password check. The singular `/proxy/generate_url` is already handled this way — this just mirrors that decision to the other three.

No real auth is bypassed: the handlers still require the correct `api_password` in the body to encrypt a token. If the password is wrong, the minted token won't decrypt on subsequent `/proxy/stream` requests, so the bypass is limited to reaching the handler's own password check.

## Test plan

- [x] `curl -X POST /generate_urls -d '{"api_password":"wrong",…}'` → token produced but unusable (same as Python proxy behaviour)
- [x] `curl -X POST /generate_urls -d '{"api_password":"correct",…}'` → tokens produced and usable
- [x] aiostreams can successfully proxy streams end-to-end