### PR TITLE
Accept token decryption as sufficient auth for /proxy/stream

### DIFF
--- a/src/auth/middleware.rs
+++ b/src/auth/middleware.rs
@@ -162,24 +162,21 @@ where
                         .realip_remote_addr()
                         .map(|s| s.to_string());
 
-                    // Decrypt and validate token
+                    // Decrypt the token. A successful decryption is itself proof
+                    // of authentication: the AES-256 key is derived from
+                    // `api_password`, so only a caller that knows the password
+                    // can produce a ciphertext that decrypts to valid JSON
+                    // ProxyData (wrong key → Pkcs7 padding error or non-JSON
+                    // garbage). No further api_password check inside the
+                    // decrypted payload is needed, and requiring one breaks
+                    // Python-proxy compatibility: neither the Python
+                    // mediaflow-proxy nor our own `generate_url(s)` handlers
+                    // embed api_password inside the encrypted payload, so the
+                    // old post-decryption check rejected every token those
+                    // code paths produced with a silent 401.
                     let proxy_data = handler
                         .decrypt(token, client_ip.as_deref())
                         .map_err(Error::from)?;
-
-                    // validate api password
-                    if proxy_data
-                        .query_params
-                        .as_ref()
-                        .and_then(|v| v.get("api_password"))
-                        .and_then(|v| v.as_str())
-                        != Some(&api_password)
-                    {
-                        return Err(AppError::Auth(
-                            "Invalid or missing authentication".to_string(),
-                        )
-                        .into());
-                    }
 
                     // Store proxy data in request extensions
                     req.extensions_mut().insert(proxy_data);


### PR DESCRIPTION
## Summary

Encrypted proxy tokens currently produce a silent 401 on every `/proxy/stream?token=...` request, even when the token is structurally valid and authentic. This breaks token mode end-to-end for both the Python-proxy compatibility surface and this crate's own URL generators.

## The logic mismatch

The auth middleware decrypts the token and then performs a second check:

```rust
if proxy_data
    .query_params
    .as_ref()
    .and_then(|v| v.get("api_password"))
    .and_then(|v| v.as_str())
    != Some(&api_password)
{
    return Err(AppError::Auth("Invalid or missing authentication".to_string()).into());
}
```

But **none** of the code paths that produce tokens actually put `api_password` inside the encrypted `query_params`:

- **Python mediaflow-proxy** (the reference implementation this crate aims to be wire-compatible with) encrypts only the client-supplied `query_params` (`d=...`, `h_*`, `r_*`, etc.) — never `api_password`. See its `utils/http_utils.py::encode_mediaflow_proxy_url` + `utils/crypto_utils.py`.
- **This crate's own generators** (`generate_url`, `generate_urls`, `generate_encrypted_or_encoded_url` in `src/proxy/handler.rs`) build `ProxyData` with only `destination`, `query_params`, `request_headers`, `response_headers`.

So every token from every generator fails the post-decryption check and the middleware emits a 401. Downstream callers (aiostreams, mediafusion, comet, …) and their players see empty stream lists / playback failures. The only log surface is the access-log `401` — no error-level log, which is why it's been hard to spot.

## Why the extra check was redundant to begin with

The AES-256 key is derived from `api_password` (`secret_key.ljust(32)[:32]` — see `auth/encryption.rs`). A caller without the password cannot produce a ciphertext that decrypts to valid JSON `ProxyData`:

- Wrong key → Pkcs7 padding error (`decrypt_padded_vec_mut` returns Err).
- Even in the fluke case where padding accidentally validates → `serde_json::from_slice` fails on the garbled bytes.

Successful decryption is therefore already cryptographic proof of authentication. The second check adds no security — it just imposes a payload invariant that nothing in the codebase actually satisfies.

## The fix

Drop the post-decryption `api_password` check. Tokens remain authenticated: an attacker without `api_password` still cannot produce a ciphertext the middleware will accept. The `AppError::Auth` returned from `handler.decrypt(...)` still rejects forged or corrupted tokens on decryption failure.

This aligns with Python's decryption-as-auth semantic and makes the three existing URL-generation endpoints actually usable without a second hidden requirement.

## Test plan

- [x] `cargo test --package mediaflow-proxy-light` — existing round-trip / expired-token / IP-mismatch tests still pass.
- [x] Generate a token via `POST /generate_urls` with `api_password` in the body, hit the resulting `/proxy/stream?token=…` URL → now streams (previously 401'd).
- [x] Forged token (encrypted with a different password) → still rejected on decryption.