### PR TITLE
Register generic /proxy scope before Xtream catch-all

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -331,6 +331,35 @@ async fn main() -> std::io::Result<()> {
             );
         }
 
+        // Generic /proxy scope — MUST be registered BEFORE the Xtream block
+        // below.  actix-web evaluates services in registration order, and
+        // Xtream's root-level catch-all /{username}/{password}/{stream_id}[.{ext}]
+        // matches any 3-segment path (e.g. /proxy/stream/foo.mkv →
+        // username=proxy, password=stream, stream_id=foo, ext=mkv), shadowing
+        // /proxy/stream/{filename:.*} and returning an "Invalid XC username
+        // format" error from short_stream_handler.
+        {
+            use epg::handler::epg_proxy_handler;
+            app = app.service(
+                web::scope("/proxy")
+                    .route("/stream", web::get().to(handler::proxy_stream_get))
+                    .route("/stream", web::head().to(handler::proxy_stream_head))
+                    .route(
+                        "/stream/{filename:.*}",
+                        web::get().to(handler::proxy_stream_get),
+                    )
+                    .route(
+                        "/stream/{filename:.*}",
+                        web::head().to(handler::proxy_stream_head),
+                    )
+                    .route("/generate_url", web::post().to(handler::generate_url))
+                    .route("/ip", web::get().to(handler::get_public_ip))
+                    // EPG proxy — XMLTV pass-through with caching (Channels DVR & all providers)
+                    .route("/epg", web::get().to(epg_proxy_handler))
+                    .route("/epg", web::head().to(epg_proxy_handler)),
+            );
+        }
+
         // ── Xtream Codes routes (Phase 4) ───────────────────────────────────────
         // MUST come after all /proxy/* sub-scopes: the short-stream catch-all
         // /{username}/{password}/{stream_id} matches any 3-segment path at root.
@@ -481,31 +510,6 @@ async fn main() -> std::io::Result<()> {
         {
             use web_ui::handler::index_handler;
             app = app.route("/", web::get().to(index_handler));
-        }
-
-        // Generic /proxy scope MUST come LAST — it prefix-matches all /proxy/*
-        // paths, so it must only run after all specific /proxy/hls, /proxy/mpd,
-        // /proxy/telegram etc. scopes have already been given a chance to match.
-        {
-            use epg::handler::epg_proxy_handler;
-            app = app.service(
-                web::scope("/proxy")
-                    .route("/stream", web::get().to(handler::proxy_stream_get))
-                    .route("/stream", web::head().to(handler::proxy_stream_head))
-                    .route(
-                        "/stream/{filename:.*}",
-                        web::get().to(handler::proxy_stream_get),
-                    )
-                    .route(
-                        "/stream/{filename:.*}",
-                        web::head().to(handler::proxy_stream_head),
-                    )
-                    .route("/generate_url", web::post().to(handler::generate_url))
-                    .route("/ip", web::get().to(handler::get_public_ip))
-                    // EPG proxy — XMLTV pass-through with caching (Channels DVR & all providers)
-                    .route("/epg", web::get().to(epg_proxy_handler))
-                    .route("/epg", web::head().to(epg_proxy_handler)),
-            );
         }
 
         app


### PR DESCRIPTION
## Summary

actix-web matches services in registration order, and Xtream's root-level catch-all

```
/{username}/{password}/{stream_id}[.{ext}]
```

matches any 3-segment path — including `/proxy/stream/foo.mkv` (`username=proxy`, `password=stream`, `stream_id=foo`, `ext=mkv`). The generic `/proxy` scope is currently registered *after* this catch-all, so requests to the Python-compat filename-in-path routes

```
/proxy/stream/{filename:.*}          (GET / HEAD)
```

are shadowed and get dispatched to `short_stream_handler` instead, which fails base64url-decoding the literal "proxy" and returns:

```json
{"error":"Invalid XC username format. Expected base64url-encoded string or legacy `{base64_upstream}:{username}[:{api_password}]`."}
```

Every caller that builds human-readable proxy URLs — aiostreams, mediafusion, or any client that appends the media filename for player format detection — hits this. Example from the wild:

```
curl 'https://<host>/proxy/stream/The.Housemaid.2025.D.BDREMUX.2160p.HDR.DVP7.seleZen.mkv?token=...'
{"error":"Invalid XC username format..."}
```

## The fix

Move the generic `/proxy` scope's registration above the Xtream block. The existing per-format `/proxy/hls`, `/proxy/mpd`, `/proxy/telegram`, `/proxy/transcode`, `/proxy/acestream` sub-scopes are already registered before the generic `/proxy` scope (and continue to be), so their more-specific routes still win over `/proxy/stream` + `/proxy/stream/{filename:.*}` defined here. Xtream's 3-segment catch-all now only matches paths that do not start with `/proxy/`, restoring the documented behaviour.

The block's explanatory comment has also been updated — the old comment ("MUST come LAST") described an intent that the code didn't match.

## Test plan

- [x] `curl /proxy/stream/<filename>.mkv?token=...` → streams (previously 401/XC error)
- [x] `curl /proxy/stream?token=...` (no filename) → still streams
- [x] `curl /<base64>/<password>/<stream_id>.ts` → still dispatched to Xtream `short_stream_handler`
- [x] `curl /proxy/hls/manifest.m3u8?...` → still dispatched to hls handler, not the generic /proxy/stream route