### PR TITLE
Fail loudly on no-auth misconfig instead of silent 500s

### DIFF
--- a/src/auth/middleware.rs
+++ b/src/auth/middleware.rs
@@ -139,8 +139,34 @@ where
         let api_password = self.api_password.clone();
 
         Box::pin(async move {
-            // If API password is not set, allow all requests
+            // No-auth mode: operator hasn't set `APP__AUTH__API_PASSWORD`.
+            // Don't silently pass through — handlers extract ReqData<ProxyData>
+            // and hard-500 with a cryptic "Missing expected request extension
+            // data" message if we don't populate it here.
             if api_password.is_empty() {
+                let has_path_token = req.path().starts_with("/_token_");
+                let query_string = req.query_string().to_owned();
+                let query_params = AuthMiddleware::extract_query_params(&query_string);
+
+                // If the caller sent an encrypted token (path- or query-style),
+                // they expect auth but the server has none configured. Surface
+                // that as an explicit, actionable 401 so the operator spots the
+                // misconfig from the response body instead of chasing silent
+                // 500s caused by missing ProxyData in the handler extractor.
+                if has_path_token || query_params.contains_key("token") {
+                    return Err(AppError::Auth(
+                        "Server has no api_password configured but request carries an \
+                         encrypted token. Set APP__AUTH__API_PASSWORD on the server to \
+                         the same value used to mint the token."
+                            .to_string(),
+                    )
+                    .into());
+                }
+
+                // Populate ProxyData from query params (d=, h_*, r_*) so
+                // handlers have a valid destination / header map to work with.
+                let proxy_data = build_proxy_data_from_query(&query_params);
+                req.extensions_mut().insert(proxy_data);
                 return service.call(req).await;
             }
 
@@ -209,37 +235,7 @@ where
             // Check for direct API password
             if let Some(password) = query_params.get("api_password").and_then(|v| v.as_str()) {
                 if password == api_password {
-                    // Accept both "d" (canonical) and "url" (Python-proxy compat) as destination.
-                    // Endpoints like /proxy/mpd/segment have no "d=" param — use empty string so
-                    // ReqData<ProxyData> extraction never fails with a 500.
-                    let destination = query_params
-                        .get("d")
-                        .or_else(|| query_params.get("url"))
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("")
-                        .to_string();
-
-                    // Build h_* and r_* sub-maps in a single pass over query_params,
-                    // then move the full map into ProxyData (no clone).
-                    let mut request_headers = serde_json::Map::new();
-                    let mut response_headers = serde_json::Map::new();
-                    for (k, v) in &query_params {
-                        if let Some(stripped) = k.strip_prefix("h_") {
-                            request_headers.insert(stripped.to_string(), v.clone());
-                        } else if let Some(stripped) = k.strip_prefix("r_") {
-                            response_headers.insert(stripped.to_string(), v.clone());
-                        }
-                    }
-
-                    let proxy_data = ProxyData {
-                        destination,
-                        query_params: Some(Value::Object(query_params)),
-                        request_headers: Some(Value::Object(request_headers)),
-                        response_headers: Some(Value::Object(response_headers)),
-                        exp: None,
-                        ip: None,
-                    };
-
+                    let proxy_data = build_proxy_data_from_query(&query_params);
                     req.extensions_mut().insert(proxy_data);
                     return service.call(req).await;
                 }
@@ -247,5 +243,40 @@ where
 
             Err(AppError::Auth("Invalid or missing authentication".to_string()).into())
         })
+    }
+}
+
+/// Build `ProxyData` from direct query-string params (`d=` or `url=` for the
+/// destination, `h_*` for request headers, `r_*` for response headers).
+///
+/// Used by both the direct-api_password branch and the no-auth passthrough
+/// branch of the middleware. Endpoints like /proxy/mpd/segment have no `d=`
+/// param, so destination falls back to an empty string rather than panicking
+/// — `ReqData<ProxyData>` extraction never fails.
+fn build_proxy_data_from_query(query_params: &serde_json::Map<String, Value>) -> ProxyData {
+    let destination = query_params
+        .get("d")
+        .or_else(|| query_params.get("url"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+
+    let mut request_headers = serde_json::Map::new();
+    let mut response_headers = serde_json::Map::new();
+    for (k, v) in query_params {
+        if let Some(stripped) = k.strip_prefix("h_") {
+            request_headers.insert(stripped.to_string(), v.clone());
+        } else if let Some(stripped) = k.strip_prefix("r_") {
+            response_headers.insert(stripped.to_string(), v.clone());
+        }
+    }
+
+    ProxyData {
+        destination,
+        query_params: Some(Value::Object(query_params.clone())),
+        request_headers: Some(Value::Object(request_headers)),
+        response_headers: Some(Value::Object(response_headers)),
+        exp: None,
+        ip: None,
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,6 +73,20 @@ async fn main() -> std::io::Result<()> {
         )
         .try_init()
         .expect("Failed to initialize logging");
+
+    // Loud warning when no API password is configured — silent no-auth mode is
+    // the most common footgun: any token-bearing request returns a cryptic 500
+    // rather than streaming, and operators chase ghosts.
+    if config.auth.api_password.is_empty() {
+        tracing::warn!(
+            "APP__AUTH__API_PASSWORD is not set — server is running in no-auth mode. \
+             Requests that carry an encrypted `?token=...` (or `/_token_/...` path) \
+             will be rejected with an explanatory 401, and callers must use direct \
+             `?d=<url>&h_*=...` mode. Set APP__AUTH__API_PASSWORD to enable \
+             token-based auth."
+        );
+    }
+
     let auth_middleware = AuthMiddleware::new(config.auth.api_password.clone());
     let stream_manager = StreamManager::new(config.proxy.clone());
     let server_config = Arc::new(config.clone());


### PR DESCRIPTION
## The footgun

When `APP__AUTH__API_PASSWORD` is unset, the server silently short-circuits the auth middleware and hands the request directly to the next service. The proxy handlers then hard-500 with a cryptic actix-internal message:

```
DEBUG actix_web::request_data: Failed to construct App-level ReqData extractor.
  Request path: "/proxy/stream/The.Housemaid.2025.BDRemux.1080p.mkv"
  (type: mediaflow_proxy_light::auth::encryption::ProxyData)
DEBUG actix_web::middleware::logger: Error in response: "Missing expected request extension data"
INFO  actix_web::middleware::logger: 10.2.27.250 - "HEAD /proxy/stream/...?token=..." 500
```

…because `handle_proxy_request` extracts `web::ReqData<ProxyData>` and the no-auth branch of the middleware never populates it.

This is by far the most common deployment footgun I've seen multi-tenant operators hit: helm chart with a templated-default password, tenant forgets to override it, pod boots with empty `api_password`, aiostreams continues minting tokens using its own configured password, every `/proxy/stream` request 500s, operator finds nothing useful in the logs and goes on a safari.

## Two tightly-scoped changes

### 1. Startup WARN

Loudly announces no-auth mode at boot so the misconfig is visible in pod logs from the first line, instead of only being discoverable through request-level triage.

### 2. Middleware no-auth branch — surface the misconfig, don't paper over it

Instead of passing through blindly, the branch now:

- **If the request carries an encrypted token** (either `?token=…` or `/_token_/…` path form): rejects with an explicit 401 whose body names the env var to set:

  > Server has no api_password configured but request carries an encrypted token. Set APP__AUTH__API_PASSWORD on the server to the same value used to mint the token.

- **Otherwise**: populates `ProxyData` from query params (`d=` / `url=`, `h_*`, `r_*`) so the direct-destination mode the existing comment advertised actually works without a password. This also eliminates the latent 500 that currently fires for any operator intentionally running no-auth mode with `?d=…&h_…=…` URLs.

The direct-api_password branch is refactored to share the same `build_proxy_data_from_query()` helper, so there's a single source of truth for the d=/h_*/r_* → ProxyData shape (no behavioural change in that branch).

## Test plan

- [x] Start with no `APP__AUTH__API_PASSWORD` → startup WARN fires; tokenless `?d=...` requests still work; token-bearing requests get a 401 with an actionable message.
- [x] Start with `APP__AUTH__API_PASSWORD` set → all three auth paths (path-token, query-token, direct api_password) continue to work exactly as before.
- [x] Existing `tests/compat_tests.rs` suite still passes (refactor preserves direct-password semantics).