### PR TITLE
fix(auth): let Xtream/IPTV routes reach self-authenticating handlers

### DIFF
--- a/src/auth/middleware.rs
+++ b/src/auth/middleware.rs
@@ -51,6 +51,45 @@ fn is_static_asset(path: &str) -> bool {
     )
 }
 
+/// Xtream Codes (IPTV) entry routes that authenticate themselves *inside* their
+/// handlers via `verify_xc_api_password`, which reads the api_password embedded in
+/// the base64 username (`base64({upstream}:{user}:{api_password})`).
+///
+/// Standard XC players (TiviMate, IPTV Smarters, UHF) can only send `username` +
+/// `password` — they cannot append `?api_password=` or a token. So the global
+/// middleware must let these routes through to their self-authenticating handlers,
+/// mirroring the Python `mediaflow-proxy`, which registers the XC router WITHOUT
+/// the global auth dependency. Auth is NOT bypassed: the handler still rejects a
+/// wrong/missing embedded password with 403.
+fn is_xtream_route(path: &str) -> bool {
+    const XC_EXACT: &[&str] = &["/player_api.php", "/xmltv.php", "/get.php", "/panel_api.php"];
+    if XC_EXACT.contains(&path) {
+        return true;
+    }
+    const XC_PREFIXES: &[&str] = &[
+        "/live/",
+        "/movie/",
+        "/series/",
+        "/timeshift/",
+        "/hls/",
+        "/hlsr/",
+    ];
+    if XC_PREFIXES.iter().any(|p| path.starts_with(p)) {
+        return true;
+    }
+    // Short-stream catch-all: /{username}/{password}/{stream_id}[.ext] — three
+    // non-empty segments whose first segment is not an internal scope prefix.
+    // The only handler matching this shape is short_stream_handler, which
+    // self-verifies, so exempting it opens no hole (non-XC paths 404).
+    let segments: Vec<&str> = path.trim_start_matches('/').split('/').collect();
+    segments.len() == 3
+        && !segments.iter().any(|s| s.is_empty())
+        && !matches!(
+            segments[0],
+            "proxy" | "extractor" | "playlist" | "speedtest" | "health" | "metrics"
+        )
+}
+
 #[derive(Clone)]
 pub struct AuthMiddleware {
     encryption_handler: Option<Arc<EncryptionHandler>>,
@@ -262,6 +301,17 @@ where
                     req.extensions_mut().insert(proxy_data);
                     return service.call(req).await;
                 }
+            }
+
+            // Xtream Codes routes self-authenticate in their handlers (the
+            // api_password is carried inside the base64 username, validated by
+            // verify_xc_api_password). XC players cannot send ?api_password or a
+            // token, so let these routes reach their handlers. ProxyData is still
+            // populated so any ReqData<ProxyData> extraction in a handler succeeds.
+            if is_xtream_route(req.path()) {
+                let proxy_data = build_proxy_data_from_query(&query_params);
+                req.extensions_mut().insert(proxy_data);
+                return service.call(req).await;
             }
 
             Err(AppError::Auth("Invalid or missing authentication".to_string()).into())


### PR DESCRIPTION
## Summary

The global auth middleware (`src/auth/middleware.rs`) only accepts `?api_password`, `?token`, or the `/_token_` path prefix. Xtream Codes players (TiviMate, IPTV Smarters, UHF, …) can **only** send `username` + `password` — they can't append a query param or token — so every XC request was rejected with **401 before its handler ran**.

The XC handlers already validate the `api_password` embedded in the base64 username (`base64({upstream}:{user}:{api_password})`) via `verify_xc_api_password`. This adds `is_xtream_route()` and lets those routes through to their self-authenticating handlers, mirroring the Python `mediaflow-proxy`, which registers the XC router **without** the global auth dependency.

**Auth is not weakened:** handlers still `403` on a wrong/missing embedded password, and `/proxy/*` (AIOStreams) stays protected by `APP__AUTH__API_PASSWORD`. The short-stream catch-all excludes the internal scope prefixes (`proxy|extractor|playlist|speedtest|health|metrics`), exactly matching the existing `not_internal_prefix` routing guard, so it can't shadow internal routes.

## Credit

Original fix authored and submitted by **@hiteshkardam** (commit `76d35f0`). Opening upstream on their behalf with authorship preserved.

## Validation

- Applies cleanly against tag `1.1.1` and compiles with the default feature set.
- Verified each XC handler calls `verify_xc_api_password` immediately after parsing credentials, before any upstream call.

## Heads-up: separate, pre-existing route/handler bugs (not addressed here)

While validating, I found several XC stream routes are broken **independent of auth**, by route-pattern ↔ handler `web::Path<…>` arity mismatches (Actix 404s when a path has fewer dynamic segments than the handler's tuple, before the handler runs). These are *not* introduced or fixed by this PR — flagging so they can be tracked separately:

- **No-extension `/live/`, `/movie/`, `/series/`** routes → 3 segments into `Path<4>`/`Path<6>` → 404.
- **`/streaming/timeshift.php`** (Stalker portal form) → 0 path segments into `timeshift_handler`'s `Path<5>` → 404; this form carries credentials in the **query string**, not the path.
- **`/hlsr/{token}/{username}/{password}/…`** → reaches `live_stream_handler` but parses `path.0` (the HLS session **token**) as the username; the username is actually `path.1`.
- **`/hls/{token}/{stream_id}.m3u8`** → 404, and architecturally can't be forwarded statelessly: `rewrite_urls_for_api` only substitutes the username segment, so an `/hls/` URL carries no upstream/credential context.

Happy to follow up with a separate PR for these if useful.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)